### PR TITLE
_make_proxy attempts to referenced undefined variable api_version

### DIFF
--- a/openstack/service_description.py
+++ b/openstack/service_description.py
@@ -196,7 +196,6 @@ class ServiceDescription(object):
                 "Service {service_type) has no discoverable version."
                 " The resulting Proxy object will only have direct"
                 " passthrough REST capabilities.".format(
-                    version=api_version,
                     service_type=self.service_type),
                 category=exceptions.UnsupportedVersionWarning)
             return temp_adapter


### PR DESCRIPTION
The `_make_proxy` function in openstack/service_description.py was
attempting to reference a variable named api_version when no such
variable was in scope. The reference was in a format string and was
not actually being used.  This commit removes the invalid reference.