### PR TITLE
Fix _get_grant_revoke_params get_group

### DIFF
--- a/openstack/cloud/_identity.py
+++ b/openstack/cloud/_identity.py
@@ -1328,7 +1328,12 @@ class IdentityCloudMixin(_normalize.Normalizer):
             data['project'] = self.get_project(project, filters=filters)
 
         if not is_keystone_v2 and group:
-            data['group'] = self.get_group(group, filters=filters)
+            if domain:
+                data['group'] = self.get_group(group,
+                                            domain_id=filters['domain_id'],
+                                            filters=filters)
+            else:
+                data['group'] = self.get_group(group, filters=filters)
 
         return data
 


### PR DESCRIPTION
Fixed  problem with get_group() in _get_grant_revoke_params() when a domain is specified.