### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/source/contributor/layout.rst
+++ b/doc/source/contributor/layout.rst
@@ -29,7 +29,7 @@ the server-side expects, as this ``prop`` becomes a mapping between the two.::
    is_public = resource.prop('os-flavor-access:is_public', type=bool)
 
 There are six additional attributes which the ``Resource`` class checks
-before making requests to the REST API. ``allow_create``, ``allow_retreive``,
+before making requests to the REST API. ``allow_create``, ``allow_retrieve``,
 ``allow_commit``, ``allow_delete``, ``allow_head``, and ``allow_list`` are set
 to ``True`` or ``False``, and are checked before making the corresponding
 method call.

--- a/openstack/cloud/_baremetal.py
+++ b/openstack/cloud/_baremetal.py
@@ -383,7 +383,7 @@ class BaremetalCloudMixin(_normalize.Normalizer):
 
         :param string name_or_id: A machine name or UUID to be updated.
         :param patch:
-           The JSON Patch document is a list of dictonary objects
+           The JSON Patch document is a list of dictionary objects
            that comply with RFC 6902 which can be found at
            https://tools.ietf.org/html/rfc6902.
 
@@ -423,7 +423,7 @@ class BaremetalCloudMixin(_normalize.Normalizer):
 
         :raises: OpenStackCloudException on operation error.
 
-        :returns: ``munch.Munch`` containing a machine sub-dictonary consisting
+        :returns: ``munch.Munch`` containing a machine sub-dictionary consisting
                   of the updated data returned from the API update operation,
                   and a list named changes which contains all of the API paths
                   that received updates.

--- a/openstack/image/_base_proxy.py
+++ b/openstack/image/_base_proxy.py
@@ -102,7 +102,7 @@ class BaseImageProxy(proxy.Proxy, metaclass=abc.ABCMeta):
             Implies ``use_import`` equals ``True``.
         :param all_stores_must_succeed:
             When set to True, if an error occurs during the upload in at
-            least one store, the worfklow fails, the data is deleted
+            least one store, the workflow fails, the data is deleted
             from stores where copying is done (not staging), and the
             state of the image is unchanged. When set to False, the
             workflow will fail (data deleted from stores, …) only if the

--- a/openstack/image/_download.py
+++ b/openstack/image/_download.py
@@ -63,7 +63,7 @@ class DownloadMixin:
             except Exception as e:
                 raise exceptions.SDKException(
                     "Unable to download image: %s" % e)
-        # if we are returning the repsonse object, ensure that it
+        # if we are returning the response object, ensure that it
         # has the content-md5 header so that the caller doesn't
         # need to jump through the same hoops through which we
         # just jumped.

--- a/openstack/image/v2/_proxy.py
+++ b/openstack/image/v2/_proxy.py
@@ -73,7 +73,7 @@ class Proxy(_base_proxy.BaseImageProxy):
             ``store`` and ``stores``.
         :param all_stores_must_succeed:
             When set to True, if an error occurs during the upload in at
-            least one store, the worfklow fails, the data is deleted
+            least one store, the workflow fails, the data is deleted
             from stores where copying is done (not staging), and the
             state of the image is unchanged. When set to False, the
             workflow will fail (data deleted from stores, …) only if the

--- a/openstack/instance_ha/v1/notification.py
+++ b/openstack/instance_ha/v1/notification.py
@@ -64,9 +64,9 @@ class Notification(resource.Resource):
     type = resource.Body("type")
     #: The hostname of this notification.
     hostname = resource.Body("hostname")
-    #: The status for this notitication.
+    #: The status for this notification.
     status = resource.Body("status")
-    #: The generated_time for this notitication.
+    #: The generated_time for this notification.
     generated_time = resource.Body("generated_time")
     #: The payload of this notification.
     payload = resource.Body("payload")

--- a/openstack/proxy.py
+++ b/openstack/proxy.py
@@ -546,7 +546,7 @@ class Proxy(adapter.Adapter):
 
         :param resource_type: The type of resource to retrieve.
         :type resource_type: :class:`~openstack.resource.Resource`
-        :param value: The value of a specific resource to retreive headers
+        :param value: The value of a specific resource to retrieve headers
                       for. Can be either the ID of a resource,
                       a :class:`~openstack.resource.Resource` subclass,
                       or ``None``.

--- a/openstack/resource.py
+++ b/openstack/resource.py
@@ -709,7 +709,7 @@ class Resource(dict):
     def items(self):
         # This method is critically required for Ansible "jsonify"
         # NOTE(gtema) For some reason when running from SDK itself the native
-        # implementation of the method is absolutely sifficient, when called
+        # implementation of the method is absolutely sufficient, when called
         # from Ansible - the values are often empty. Even integrating all
         # Ansible internal methods did not help to find the root cause. Another
         # fact is that under Py2 everything is fine, while under Py3 it fails.


### PR DESCRIPTION
There are small typos in:
- doc/source/contributor/layout.rst
- openstack/cloud/_baremetal.py
- openstack/image/_base_proxy.py
- openstack/image/_download.py
- openstack/image/v2/_proxy.py
- openstack/instance_ha/v1/notification.py
- openstack/proxy.py
- openstack/resource.py

Fixes:
- Should read `workflow` rather than `worfklow`.
- Should read `retrieve` rather than `retreive`.
- Should read `notification` rather than `notitication`.
- Should read `dictionary` rather than `dictonary`.
- Should read `sufficient` rather than `sifficient`.
- Should read `response` rather than `repsonse`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md