### PR TITLE
Issue to fix security_group.name returning null

### DIFF
--- a/openstack/compute/v2/_proxy.py
+++ b/openstack/compute/v2/_proxy.py
@@ -1212,7 +1212,7 @@ class Proxy(proxy.Proxy):
         """
         server = self._get_resource(_server.Server, server)
         security_group = self._get_resource(_sg.SecurityGroup, security_group)
-        server.add_security_group(self, security_group.name)
+        server.add_security_group(self, security_group.id)
 
     def remove_security_group_from_server(self, server, security_group):
         """Remove a security group from a server
@@ -1227,7 +1227,7 @@ class Proxy(proxy.Proxy):
         """
         server = self._get_resource(_server.Server, server)
         security_group = self._get_resource(_sg.SecurityGroup, security_group)
-        server.remove_security_group(self, security_group.name)
+        server.remove_security_group(self, security_group.id)
 
     # ========== Server IPs ==========
 


### PR DESCRIPTION
Hi team,

I'm writing to request a pull request to fix the issue with security_group.name returning null. This issue is causing problems for users who are trying add or remove security group from a server.

Follow the error message:

BadRequestException: 400: Client Error for url: https://<url>/v2.1/<uuid>/servers/<uuid>/action, **Security group name cannot be empty**

I've attached a patch that fixes this issue. Replacing security_group.name for security_group.id

I've tested this patch and it works correctly. 

Thanks,
Petryx