### PR TITLE
[Filter instances] if a key doesnt exist, ignore instance instance to  raise error

### DIFF
--- a/openstack/cloud/_utils.py
+++ b/openstack/cloud/_utils.py
@@ -123,7 +123,7 @@ def _filter_list(data, name_or_id, filters):
                 # we intentionally skip this since the user was trying to
                 # filter on _something_, but we don't know what that
                 # _something_ was
-                raise AttributeError(key)
+                return False
             if isinstance(f[key], dict):
                 if not _dict_filter(f[key], d.get(key, None)):
                     return False


### PR DESCRIPTION
Version 1.4.0 and 1.5.0 raises error when trying to filter from an existing key

Example, using Ansible (openstack.cloud collection):

      os_server_info:
        server: "*"
        filters:
          metadata:
            guid: "{{ guid }}"

this trows error on version 1.4.0/1.5.0 but not on 1.3.1