### PR TITLE
Bugfix / openstack project cleanup trips and falls on used security groups

### DIFF
--- a/openstack/network/v2/_proxy.py
+++ b/openstack/network/v2/_proxy.py
@@ -7253,23 +7253,6 @@ class Proxy(proxy.Proxy):
                     resource_evaluation_fn=fip_cleanup_evaluation,
                 )
 
-        if not self.should_skip_resource_cleanup(
-            "security_group", skip_resources
-        ):
-            # Delete (try to delete) all security groups in the project
-            # Let's hope we can't drop SG in use
-            for obj in self.security_groups(project_id=project_id):
-                if obj.name != 'default':
-                    self._service_cleanup_del_res(
-                        self.delete_security_group,
-                        obj,
-                        dry_run=dry_run,
-                        client_status_queue=client_status_queue,
-                        identified_resources=identified_resources,
-                        filters=filters,
-                        resource_evaluation_fn=resource_evaluation_fn,
-                    )
-
         if not (
             self.should_skip_resource_cleanup("network", skip_resources)
             or self.should_skip_resource_cleanup("router", skip_resources)
@@ -7418,6 +7401,23 @@ class Proxy(proxy.Proxy):
                         identified_resources=identified_resources,
                         filters=None,
                         resource_evaluation_fn=None,
+                    )
+
+        if not self.should_skip_resource_cleanup(
+            "security_group", skip_resources
+        ):
+            # Delete (try to delete) all security groups in the project
+            # Let's hope we can't drop SG in use
+            for obj in self.security_groups(project_id=project_id):
+                if obj.name != 'default':
+                    self._service_cleanup_del_res(
+                        self.delete_security_group,
+                        obj,
+                        dry_run=dry_run,
+                        client_status_queue=client_status_queue,
+                        identified_resources=identified_resources,
+                        filters=filters,
+                        resource_evaluation_fn=resource_evaluation_fn,
                     )
 
 


### PR DESCRIPTION
Currently, project cleanup does correctly delete network resources while security groups are in use.

openstack project cleanup --auth-project
+---------------+--------------------------------------+---------------------+
| Type          | ID                                   | Name                |
+---------------+--------------------------------------+---------------------+
| SecurityGroup | bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc | shoot--jgnaucke--cd |
+---------------+--------------------------------------+---------------------+
These resources will be deleted. Are you sure [y/n]: y
Deleting resources
Cannot delete resource openstack.network.v2.security_group.SecurityGroup(id=bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc, name=shoot--jgnaucke--cd, stateful=True, tenant_id=030ffb6bd30144e692ed97b331a5583e, description=Cluster Nodes, security_group_rules=[{'id': '27a97baf-7fd6-4c95-8f68-a0e6a1e53c52', 'project_id': '030ffb6bd30144e692ed97b331a5583e', 'tenant_id': '030ffb6bd30144e692ed97b331a5583e', 'security_group_id': 'bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc', 'ethertype': 'IPv4', 'direction': 'ingress', 'protocol': 'tcp', 'port_range_min': 30000, 'port_range_max': 32767, 'remote_ip_prefix': '0.0.0.0/0', 'remote_address_group_id': None, 'normalized_cidr': '0.0.0.0/0', 'remote_group_id': None, 'standard_attr_id': 14180582, 'belongs_to_default_sg': False, 'description': 'IPv4: allow all incoming tcp traffic with port range 30000-32767', 'tags': [], 'created_at': '2024-07-12T01:31:31Z', 'updated_at': '2024-07-12T01:31:31Z', 'revision_number': 0}, {'id': '91526e29-526b-4e1d-8042-46196d01fb79', 'project_id': '030ffb6bd30144e692ed97b331a5583e', 'tenant_id': '030ffb6bd30144e692ed97b331a5583e', 'security_group_id': 'bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc', 'ethertype': 'IPv4', 'direction': 'ingress', 'protocol': 'udp', 'port_range_min': 30000, 'port_range_max': 32767, 'remote_ip_prefix': '0.0.0.0/0', 'remote_address_group_id': None, 'normalized_cidr': '0.0.0.0/0', 'remote_group_id': None, 'standard_attr_id': 14180591, 'belongs_to_default_sg': False, 'description': 'IPv4: allow all incoming udp traffic with port range 30000-32767', 'tags': [], 'created_at': '2024-07-12T01:31:31Z', 'updated_at': '2024-07-12T01:31:31Z', 'revision_number': 0}, {'id': 'f19eeb8a-84c3-419a-bf28-14f663c360b4', 'project_id': '030ffb6bd30144e692ed97b331a5583e', 'tenant_id': '030ffb6bd30144e692ed97b331a5583e', 'security_group_id': 'bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc', 'ethertype': 'IPv4', 'direction': 'egress', 'protocol': None, 'port_range_min': None, 'port_range_max': None, 'remote_ip_prefix': None, 'remote_address_group_id': None, 'normalized_cidr': None, 'remote_group_id': None, 'standard_attr_id': 14180585, 'belongs_to_default_sg': False, 'description': 'IPv4: allow all outgoing traffic', 'tags': [], 'created_at': '2024-07-12T01:31:31Z', 'updated_at': '2024-07-12T01:31:31Z', 'revision_number': 0}, {'id': 'f989495e-ffee-48e4-ba4c-81c8d1442832', 'project_id': '030ffb6bd30144e692ed97b331a5583e', 'tenant_id': '030ffb6bd30144e692ed97b331a5583e', 'security_group_id': 'bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc', 'ethertype': 'IPv4', 'direction': 'ingress', 'protocol': None, 'port_range_min': None, 'port_range_max': None, 'remote_ip_prefix': None, 'remote_address_group_id': None, 'normalized_cidr': None, 'remote_group_id': 'bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc', 'standard_attr_id': 14180588, 'belongs_to_default_sg': False, 'description': 'IPv4: allow all incoming traffic within the same security group', 'tags': [], 'created_at': '2024-07-12T01:31:31Z', 'updated_at': '2024-07-12T01:31:31Z', 'revision_number': 0}], tags=[], created_at=2023-09-07T16:12:16Z, updated_at=2024-07-12T01:31:31Z, revision_number=15, project_id=030ffb6bd30144e692ed97b331a5583e, shared=False, location=Munch({'cloud': '', 'region_name': 'intern1', 'zone': None, 'project': Munch({'id': '030ffb6bd30144e692ed97b331a5583e', 'name': None, 'domain_id': None, 'domain_name': None})})): ConflictException: 409: Client Error for url: https://intern1.api.pco.get-cloud.io:9696/v2.0/security-groups/bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc, Security Group bb307cf8-4e1c-4fa1-a1eb-ee641f8a66bc in use.
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/openstackclient/7.4.0/libexec/lib/python3.13/site-packages/openstack/proxy.py", line 847, in _service_cleanup_del_res
    del_fn(obj)
    ~~~~~~^^^^^
  File "/opt/homebrew/Cellar/openstackclient/7.4.0/libexec/lib/python3.13/site-packages/openstack/network/v2/_proxy.py", line 4774, in delete_security_group
    self._delete(
    ~~~~~~~~~~~~^
        _security_group.SecurityGroup,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        if_revision=if_revision,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^

Reason is that https://github.com/openstack/openstacksdk/blob/master/openstack/network/v2/_proxy.py#L7256 tries to delete Security Groups before cleaning up network resources that might use these security groups.

-fix->

Delete Security Groups after deleting network resources.